### PR TITLE
Call SDL_Quit after SDL_GetError

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -141,19 +141,17 @@ main(int argc, char* argv[])
         flags);
 
     if (window == NULL) {
-        SDL_Quit();
-
         fprintf(stderr, "failed to create SDL2 window: %s\n", SDL_GetError());
+        SDL_Quit();
         return EXIT_FAILURE;
     }
 
     // SDL_GLContext is an alias for "void*"
     SDL_GLContext context = SDL_GL_CreateContext(window);
     if (context == NULL) {
+        fprintf(stderr, "failed to create OpenGL context: %s\n", SDL_GetError());
         SDL_DestroyWindow(window);
         SDL_Quit();
-
-        fprintf(stderr, "failed to create OpenGL context: %s\n", SDL_GetError());
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
Here is the problem:
```
$ make
cc -std=c99 -fPIC -g -Og -Wall -Wextra -Wpedantic -Wno-unused-parameter -Wno-unused-result -Wno-unused-function -Isrc/  -o demo src/main.c src/opengl.c -lGL -lSDL2
$ MESA_GL_VERSION_OVERRIDE=1.5 ./demo 
Platform:        Linux
CPU Count:       12
System RAM:      64242 MB
Supports SSE:    true
Supports SSE2:   true
Supports SSE3:   true
Supports SSE4.1: true
Supports SSE4.2: true
failed to create OpenGL context:
```
As you can see, the message returned by SDL_GetError is not shown because SDL_Quit is called before SDL_GetError.
Here is the fix:
```
$ make
cc -std=c99 -fPIC -g -Og -Wall -Wextra -Wpedantic -Wno-unused-parameter -Wno-unused-result -Wno-unused-function -Isrc/  -o demo src/main.c src/opengl.c -lGL -lSDL2
$ MESA_GL_VERSION_OVERRIDE=1.5 ./demo 
Platform:        Linux
CPU Count:       12
System RAM:      64242 MB
Supports SSE:    true
Supports SSE2:   true
Supports SSE3:   true
Supports SSE4.1: true
Supports SSE4.2: true
failed to create OpenGL context: Could not create GL context: GLXBadFBConfig
```
As you can see, the message returned by SDL_GetError is now shown because SDL_Quit is called after SDL_GetError.
Problem fixed.